### PR TITLE
Added update order status

### DIFF
--- a/service/models/order.py
+++ b/service/models/order.py
@@ -5,13 +5,15 @@ from enum import Enum
 
 logger = logging.getLogger("flask.app")
 
+
 class Order_Status(Enum):
     """Enumeration of valid order statuses"""
 
-    Created = 'Created'
-    In_Progress = 'In_Progress'
-    Shipped = 'Shipped'
-    Completed = 'Completed'
+    Created = "Created"
+    In_Progress = "In_Progress"
+    Shipped = "Shipped"
+    Completed = "Completed"
+    Cancelled = "Cancelled"
 
 
 class Order(db.Model, PersistentBase):
@@ -21,7 +23,9 @@ class Order(db.Model, PersistentBase):
 
     id = db.Column(db.Integer, primary_key=True)
     customer_name = db.Column(db.String(64), nullable=False)
-    status = db.Column(db.Enum(Order_Status), default=Order_Status.Created, nullable=False)
+    status = db.Column(
+        db.Enum(Order_Status), default=Order_Status.Created, nullable=False
+    )
     items = db.relationship("Item", backref="order", passive_deletes=True)
 
     def __repr__(self):
@@ -30,8 +34,10 @@ class Order(db.Model, PersistentBase):
     def serialize(self):
         """Converts an Order into a dictionary"""
         if not isinstance(self.status, Order_Status):
-            raise DataValidationError(f"Invalid status value '{self.status}' not in Order_Status Enum")
-        
+            raise DataValidationError(
+                f"Invalid status value '{self.status}' not in Order_Status Enum"
+            )
+
         return {
             "id": self.id,
             "customer_name": self.customer_name,
@@ -48,7 +54,9 @@ class Order(db.Model, PersistentBase):
             try:
                 self.status = Order_Status(data["status"])
             except ValueError:
-                raise DataValidationError(f"Invalid status value '{data['status']}' not in Order_Status Enum")
+                raise DataValidationError(
+                    f"Invalid status value '{data['status']}' not in Order_Status Enum"
+                )
             item_list = data.get("items", [])
             for item_data in item_list:
                 item = Item()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -112,7 +112,9 @@ class TestOrderService(TestCase):
 
         # Check the data is correct
         new_order = resp.get_json()
-        self.assertEqual(new_order["status"], order.status.value, "status does not match")
+        self.assertEqual(
+            new_order["status"], order.status.value, "status does not match"
+        )
         self.assertEqual(
             new_order["customer_name"],
             order.customer_name,
@@ -124,7 +126,9 @@ class TestOrderService(TestCase):
         resp = self.client.get(location, content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         new_order = resp.get_json()
-        self.assertEqual(new_order["status"], order.status.value, "status does not match")
+        self.assertEqual(
+            new_order["status"], order.status.value, "status does not match"
+        )
         self.assertEqual(
             new_order["customer_name"],
             order.customer_name,
@@ -543,3 +547,92 @@ class TestOrderService(TestCase):
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_order_status(self):
+        """It should update an order's status"""
+        # Create a new order
+        order = self._create_orders(1)[0]
+
+        # Test status update flow: Created -> In_Progress -> Shipped -> Completed
+        status_flow = ["In_Progress", "Shipped", "Completed"]
+
+        for new_status in status_flow:
+            resp = self.client.put(
+                f"{BASE_URL}/{order.id}/status",
+                json={"status": new_status},
+                content_type="application/json",
+            )
+            self.assertEqual(resp.status_code, status.HTTP_200_OK)
+            data = resp.get_json()
+            self.assertEqual(data["status"], new_status)
+
+    def test_update_order_idempotent(self):
+        """It should be idempotent when updating to same status"""
+        order = self._create_orders(1)[0]
+
+        # Set initial status
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/status",
+            json={"status": "In_Progress"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # Try to update with the same status
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/status",
+            json={"status": "In_Progress"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["status"], "In_Progress")
+
+    def test_update_cancelled_order_status(self):
+        """It should not update status of cancelled order"""
+        order = self._create_orders(1)[0]
+
+        # First cancel the order
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/status",
+            json={"status": "Cancelled"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # Try to update cancelled order's status
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/status",
+            json={"status": "In_Progress"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_order_status_invalid(self):
+        """It should not update status with invalid value"""
+        order = self._create_orders(1)[0]
+        invalid_status = "INVALID_STATUS"
+
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/status",
+            json={"status": invalid_status},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_order_status_not_found(self):
+        """It should not update status of non-existent order"""
+        resp = self.client.put(
+            f"{BASE_URL}/0/status",
+            json={"status": "In_Progress"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_order_status_bad_request(self):
+        """It should not update status with missing status field"""
+        order = self._create_orders(1)[0]
+        resp = self.client.put(
+            f"{BASE_URL}/{order.id}/status", json={}, content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Made the following changes:
Added endpoint to update order status

- Implemented PUT /orders/{id}/status endpoint to update order status
- Added status validation and error handling
- Prevent status changes for cancelled orders
- Added unit tests for the new endpoint
