### PR TITLE
Revert "Added update order status"

### DIFF
--- a/service/models/order.py
+++ b/service/models/order.py
@@ -5,15 +5,13 @@ from enum import Enum
 
 logger = logging.getLogger("flask.app")
 
-
 class Order_Status(Enum):
     """Enumeration of valid order statuses"""
 
-    Created = "Created"
-    In_Progress = "In_Progress"
-    Shipped = "Shipped"
-    Completed = "Completed"
-    Cancelled = "Cancelled"
+    Created = 'Created'
+    In_Progress = 'In_Progress'
+    Shipped = 'Shipped'
+    Completed = 'Completed'
 
 
 class Order(db.Model, PersistentBase):
@@ -23,9 +21,7 @@ class Order(db.Model, PersistentBase):
 
     id = db.Column(db.Integer, primary_key=True)
     customer_name = db.Column(db.String(64), nullable=False)
-    status = db.Column(
-        db.Enum(Order_Status), default=Order_Status.Created, nullable=False
-    )
+    status = db.Column(db.Enum(Order_Status), default=Order_Status.Created, nullable=False)
     items = db.relationship("Item", backref="order", passive_deletes=True)
 
     def __repr__(self):
@@ -34,10 +30,8 @@ class Order(db.Model, PersistentBase):
     def serialize(self):
         """Converts an Order into a dictionary"""
         if not isinstance(self.status, Order_Status):
-            raise DataValidationError(
-                f"Invalid status value '{self.status}' not in Order_Status Enum"
-            )
-
+            raise DataValidationError(f"Invalid status value '{self.status}' not in Order_Status Enum")
+        
         return {
             "id": self.id,
             "customer_name": self.customer_name,
@@ -54,9 +48,7 @@ class Order(db.Model, PersistentBase):
             try:
                 self.status = Order_Status(data["status"])
             except ValueError:
-                raise DataValidationError(
-                    f"Invalid status value '{data['status']}' not in Order_Status Enum"
-                )
+                raise DataValidationError(f"Invalid status value '{data['status']}' not in Order_Status Enum")
             item_list = data.get("items", [])
             for item_data in item_list:
                 item = Item()

--- a/service/routes.py
+++ b/service/routes.py
@@ -24,7 +24,7 @@ and Delete Order
 from flask import jsonify, request, url_for, abort
 from flask import current_app as app  # Import Flask application
 from service.common import status  # HTTP Status Codes
-from service.models import Order, Item, Order_Status  # Added Order_Status import
+from service.models import Order, Item
 
 
 ######################################################################
@@ -322,51 +322,3 @@ def trigger_500():
         status.HTTP_500_INTERNAL_SERVER_ERROR,
         "Test internal server error",
     )
-
-
-######################################################################
-# Update Order Status
-######################################################################
-@app.route("/orders/<int:order_id>/status", methods=["PUT"])
-def update_order_status(order_id):
-    """Update the status of an Order"""
-    app.logger.info("Request to update order status for order with id: %s", order_id)
-    check_content_type("application/json")
-
-    # Find the order by ID
-    order = Order.find(order_id)
-    if not order:
-        abort(
-            status.HTTP_404_NOT_FOUND,
-            f"Order with id '{order_id}' was not found.",
-        )
-
-    # Get the new status from request body
-    data = request.get_json()
-    if not data or "status" not in data:
-        abort(
-            status.HTTP_400_BAD_REQUEST,
-            "Required field 'status' missing from request body",
-        )
-
-    try:
-        new_status = Order_Status(data["status"])
-
-        # If current status is Cancelled, don't allow any changes
-        if order.status == Order_Status.Cancelled:
-            abort(
-                status.HTTP_400_BAD_REQUEST,
-                "Cannot update status of a cancelled order",
-            )
-
-        # If the status is not changing, return success (idempotent)
-        if order.status == new_status:
-            return jsonify(order.serialize()), status.HTTP_200_OK
-
-        # Update the status
-        order.status = new_status
-        order.update()
-        return jsonify(order.serialize()), status.HTTP_200_OK
-
-    except ValueError as error:
-        abort(status.HTTP_400_BAD_REQUEST, f"Invalid status value: {str(error)}")


### PR DESCRIPTION
Made the following changes:
Added endpoint to update order status

- Implemented PUT /orders/{id}/status endpoint to update order status
- Added status validation and error handling
- Prevent status changes for cancelled orders
- Added unit tests for the new endpoint
